### PR TITLE
New submodule: `terraform-dataproc-yandex`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "terraform-dataproc-yandex"]
+	path = terraform-dataproc-yandex
+	url = https://github.com/yasenn/terraform-dataproc-yandex


### PR DESCRIPTION
Please consider this manifest to deploy _managed_ Data Proc service:

[[yasenn/terraform-dataproc-yandex: Terraform for Yandex Data Proc managed cluster.](https://github.com/yasenn/terraform-dataproc-yandex)](https://github.com/yasenn/terraform-dataproc-yandex)

- [[v2](https://cloud.yandex.ru/docs/data-proc/release-notes/images#2.0)](https://cloud.yandex.ru/docs/data-proc/release-notes/images#2.0) by default
- 3 [[roles](https://cloud.yandex.ru/docs/managed-elasticsearch/concepts/hosts-roles)](https://cloud.yandex.ru/docs/managed-elasticsearch/concepts/hosts-roles):
    - `MASTERNODE`
    - `COMPUTENODE`
    - `DATANODE`
- [[environments](https://cloud.yandex.ru/docs/data-proc/concepts/environment)](https://cloud.yandex.ru/docs/data-proc/concepts/environment):
    - HDFS
    - YARN
    - SPARK
    - TEZ
    - MAPREDUCE
    - HIVE